### PR TITLE
Update writing-a-principle.md

### DIFF
--- a/docs/standards/writing-a-principle.md
+++ b/docs/standards/writing-a-principle.md
@@ -24,7 +24,6 @@ Ofqual principles will be written to include each of the components described be
 - [A principle MUST have tags](#a-principle-must-have-tags)
 - [A principle MUST show the role of the person that owns the principle](#a-principle-must-show-the-role-of-the-person-that-owns-the-principle)
 - [A principle MUST show when it was last updated](#a-principle-must-show-when-it-was-last-updated)
-- [A principle MUST show when it was last reviewed](#a-principle-must-show-when-it-was-last-reviewed)
 
 ---
 
@@ -78,19 +77,11 @@ Write the name of the role which owns the principle. eg 'Associate Director of P
 
 ### A principle MUST show when it was last updated
 
-Show the date the principle was last updated. The metadata needs to include the date in YYYY-MM-DD format (see below).
+Show the date the principle was last updated. This is also the date the principle was last reviewed (if not actually updated at that point). Principles should be reviewd at least every 2 years to ensure that they continue to align with (the principle needs to support) the defined organisational and technical strategies.
+The metadata needs to include the date in YYYY-MM-DD format (see below).
 
 ```yaml
 date: 2023-12-31
-```
----
-
-### A principle MUST show when it was last reviewed
-
-Show the date the principle was last reviewed. The metadata needs to include the date in YYYY-MM-DD format (see below). This should be at least every 2 years and align with (the principle needs to support) the defined organisational and technical strategies.
-
-```yaml
-date: 2024-12-31
 ```
 ---
 


### PR DESCRIPTION
Changed the 'update date' words to include the requirement to update when reviewed / combine these together in the single section.

# Content change

## Accessibility considerations
- [x ] Please review the [accessibility checks for content changes](https://github.com/OfqualGovUK/ofqual-standards-patterns/blob/main/technical-docs/accessibility/content-checks.md).

I can confirm:
- [x ] Content does not include any code or configuration changes (excluding frontmatter information)

- [ x] Content meets the content standards
e.g. [Writing a principle](/docs/standards/writing-a-principle.md) and [Writing a standard](/docs/standards/writing-a-standard.md))

- [ x] Content is suitable to open source, i.e.:

    - Content does not relate to unreleased gov policy

    - Content does not refer to anti-fraud mechanisms

    - Content does not include sensitive business logic

- [ x] Last updated date for content is correct

