### PR TITLE
FEATURE [#112]: Add a Dockerfile + supporting commands for using the app as a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Stage 1: Build the site
+FROM node:lts-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build  # or 'npx @11ty/eleventy'
+
+# Stage 2: Serve the site
+FROM nginx:alpine
+# Copy built files from Stage 1 to Nginx
+COPY --from=build /app/_site /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # Stage 1: Build the site
-FROM node:lts-alpine AS build
+FROM node:22 AS build
 WORKDIR /app
 COPY package*.json ./
+COPY .github ./.github
+
 RUN npm install
 COPY . .
 RUN npm run build  # or 'npx @11ty/eleventy'

--- a/README.md
+++ b/README.md
@@ -52,5 +52,30 @@ Installs the server globally and then navigate to a terminal/cmd prompt to the _
 http-server -p 8080
 ```
 
-Now you can preview the site on http://localhost:8080
+Now you can preview the site on `http://localhost:8080`
 
+### Alternative method for previewing changes locally via Docker
+
+Alternatively, you can run the site using the provided Dockerfile and a working and running Docker Desktop installation. To do this, run:
+
+```
+npm run docker:build
+```
+
+To generate an image named `ofqual-standards-patterns` with the tag `latest`
+
+To then run this image, use:
+
+```
+npm run docker:run
+```
+
+To host the image at `http://localhost:8080`
+
+If this port is not suitable, you may use:
+
+```
+docker run -p <PREFERRED_PORT>:80 ofqual-standards-patterns
+```
+
+To host the image at `http://localhost:<PREFERRED_PORT>`

--- a/package-lock.json
+++ b/package-lock.json
@@ -973,7 +973,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
@@ -990,7 +991,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -1663,7 +1665,6 @@
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.2.tgz",
       "integrity": "sha512-eHV8EMxYNjc+omFhB0HktQ3QmA3ZRdDsgRDlUIik+TpUHerR3XKXpo4zh/OGO2/C2mz65cX0XT0k4QrRFJZU8Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -2021,7 +2022,6 @@
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -2419,7 +2419,6 @@
       "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
       "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "posthtml-parser": "^0.11.0",
         "posthtml-render": "^3.0.0"
@@ -2546,7 +2545,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.2.tgz",
       "integrity": "sha512-BgLRGy7tNS9H66aIMASq1qSYbAAJV6Z6WR4QYTvj5FgF15rZ/ympT1uixHXwzbZUBDbkvqUI1KR0fH1FhMaQ9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "scripts": {
     "build": "eleventy",
     "serve": "eleventy --serve",
-    "docker:build": "docker build -t ofqual-standards-patterns ."
+    "docker:build": "docker build -t ofqual-standards-patterns .",
+    "docker:run": "docker run -p 8080:80 ofqual-standards-patterns"
   },
   "engines": {
     "node": ">=22.0.0 <23.0.0"


### PR DESCRIPTION
Is this pull request a content or a code change? Code Change, resolves #112 

# Code change

## Accessibility considerations
- [x] Please review the [accessibility checks for layout changes](https://github.com/OfqualGovUK/ofqual-standards-patterns/blob/main/technical-docs/accessibility/layout-checks.md).

- [x] This change will not change layouts, page structures or anything else that might impact accessibility

**OR**

- [ ] This change might impact accessibility - manual testing has been performed
(If the change might impact accessibility then please add some further information below)

This change introduces a working Dockerfile, which builds using Node 22 and executes with nginx-alpine (for better end-image size), and supporting commands in package.json to allow the application to be ran via a Docker Container.

To try this out, a developer should run:

`npm run-script docker:build`
`npm run-script docker:run`

This will run the site on `http//localhost:8080`.

The README has been updated to include instructions on running.

You may wish to investigate using node:22-alpine in the future to improve build times, although this will require some additional Dockerfile modifications to try and get Git installed, as the build process relies on this for page permalinks, and Git is not installed by default on Alpine images (this is more challenging than you think as you need to install package manager certificates yourself, which you need to provide and add to the repo, and I didn't feel it was worth working through at this stage)

